### PR TITLE
Updated NextJS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "coveralls": "^2.13.1",
     "del-cli": "^1.1.0",
     "jest": "^20.0.4",
-    "next": "^4.1.4",
+    "next": "^8.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",


### PR DESCRIPTION
Currently npm prepublish is generating a babel transpiled version that doesn't work with newer NextJS version (baking out module paths). This change would break compatibility with older next js versions. Reference issue #9.